### PR TITLE
fix: add prevBlockNumber to Transaction

### DIFF
--- a/src/types/Transaction.ts
+++ b/src/types/Transaction.ts
@@ -12,6 +12,7 @@ export default class Transaction {
   constructor(
     public depositContractAddress: Address,
     public range: Range,
+    public prevBlockNumber: BigNumber,
     public stateObject: Property,
     public from: Address,
     public signature: Bytes = Bytes.default()
@@ -24,6 +25,7 @@ export default class Transaction {
     return new Transaction(
       Address.default(),
       new Range(BigNumber.default(), BigNumber.default()),
+      BigNumber.default(),
       new Property(Address.default(), []),
       Address.default(),
       Bytes.default()
@@ -34,6 +36,7 @@ export default class Transaction {
     return new Struct([
       { key: 'depositContractAddress', value: Address.default() },
       { key: 'range', value: Range.getParamType() },
+      { key: 'prevBlockNumber', value: BigNumber.default() },
       { key: 'stateObject', value: Property.getParamType() },
       { key: 'from', value: Address.default() },
       { key: 'signature', value: Bytes.default() }
@@ -43,13 +46,15 @@ export default class Transaction {
   public static fromStruct(struct: Struct): Transaction {
     const depositContractAddress = struct.data[0].value as Address
     const range = struct.data[1].value as Struct
-    const stateObject = struct.data[2].value as Struct
-    const from = struct.data[3].value as Address
-    const signature = struct.data[4].value as Bytes
+    const prevBlockNumber = struct.data[2].value as BigNumber
+    const stateObject = struct.data[3].value as Struct
+    const from = struct.data[4].value as Address
+    const signature = struct.data[5].value as Bytes
 
     return new Transaction(
       depositContractAddress as Address,
       Range.fromStruct(range as Struct),
+      prevBlockNumber,
       Property.fromStruct(stateObject as Struct),
       from as Address,
       signature as Bytes
@@ -60,6 +65,7 @@ export default class Transaction {
     return new Struct([
       { key: 'depositContractAddress', value: this.depositContractAddress },
       { key: 'range', value: this.range.toStruct() },
+      { key: 'prevBlockNumber', value: this.prevBlockNumber },
       { key: 'stateObject', value: this.stateObject.toStruct() },
       { key: 'from', value: this.from },
       { key: 'signature', value: this.signature }
@@ -70,6 +76,7 @@ export default class Transaction {
     return new Struct([
       { key: 'depositContractAddress', value: this.depositContractAddress },
       { key: 'range', value: this.range.toStruct() },
+      { key: 'prevBlockNumber', value: this.prevBlockNumber },
       { key: 'stateObject', value: this.stateObject.toStruct() },
       { key: 'from', value: this.from }
     ])
@@ -77,5 +84,14 @@ export default class Transaction {
 
   public getHash(): Bytes {
     return Keccak256.hash(EthCoder.encode(this.body))
+  }
+
+  public toProperty(deciderAddress: Address): Property {
+    return new Property(deciderAddress, [
+      Bytes.fromHexString(this.depositContractAddress.raw),
+      this.range.toBytes(),
+      Bytes.fromHexString(this.prevBlockNumber.toHexString()).padZero(32),
+      EthCoder.encode(this.stateObject.toStruct())
+    ])
   }
 }


### PR DESCRIPTION
I guess we should discuss more but we need prevBlockNumber at this time.
This is because to get a transaction from witness database and also to avoid replay attack.